### PR TITLE
[FEAT] 건강상태 CRUD api 구현

### DIFF
--- a/src/main/java/com/onebridge/ouch/apiPayload/code/error/MedicalHistoryErrorCode.java
+++ b/src/main/java/com/onebridge/ouch/apiPayload/code/error/MedicalHistoryErrorCode.java
@@ -1,0 +1,18 @@
+package com.onebridge.ouch.apiPayload.code.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MedicalHistoryErrorCode implements ErrorCode {
+
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "HEALTH-STATUS400", "User not found."),
+	MEDICAL_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "HEALTH-STATUS401", "Health status not found.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/onebridge/ouch/controller/medicalHistory/MedicalHistoryController.java
+++ b/src/main/java/com/onebridge/ouch/controller/medicalHistory/MedicalHistoryController.java
@@ -1,0 +1,66 @@
+package com.onebridge.ouch.controller.medicalHistory;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.onebridge.ouch.dto.MessageResponse;
+import com.onebridge.ouch.dto.medicalHistory.request.MedicalHistoryCreateRequest;
+import com.onebridge.ouch.dto.medicalHistory.request.MedicalHistoryUpdateRequest;
+import com.onebridge.ouch.dto.medicalHistory.response.DateAndDisease;
+import com.onebridge.ouch.dto.medicalHistory.response.GetMedicalHistoryResponse;
+import com.onebridge.ouch.dto.medicalHistory.response.MedicalHistoryCreateResponse;
+import com.onebridge.ouch.dto.medicalHistory.response.MedicalHistoryUpdateResponse;
+import com.onebridge.ouch.service.medicalHistory.MedicalHistoryService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/health-status")
+@RequiredArgsConstructor
+public class MedicalHistoryController {
+
+	private final MedicalHistoryService medicalHistoryService;
+
+	//건강상태 생성
+	@PostMapping("/{userId}")
+	public MedicalHistoryCreateResponse createMedicalHistory(@RequestBody @Valid MedicalHistoryCreateRequest request,
+		@PathVariable Long userId) {
+		return medicalHistoryService.createMedicalHistory(request, userId);
+	}
+
+	//특정 건강상태 조회
+	@GetMapping("/{userId}/{healthStatusId}")
+	public GetMedicalHistoryResponse getMedicalHistory(@PathVariable Long healthStatusId) {
+		return medicalHistoryService.getMedicalHistory(healthStatusId);
+	}
+
+	//특정 사용자의 모든 건강상태 조회
+	@GetMapping("/get-all/{userId}")
+	public List<DateAndDisease> getUsersAllMedicalHistory(@PathVariable Long userId) {
+		return medicalHistoryService.getUsersAllMedicalHistory(userId);
+	}
+
+	//특정 건강상태 수정
+	@PutMapping("/{userId}/{healthStatusId}")
+	public MedicalHistoryUpdateResponse updateMedicalHistory(@RequestBody @Valid MedicalHistoryUpdateRequest request,
+		@PathVariable Long healthStatusId) {
+		return medicalHistoryService.updateMedicalHistory(request, healthStatusId);
+	}
+
+	//특정 건강상태 삭제
+	@DeleteMapping("/{userId}/{healthStatusId}")
+	public ResponseEntity<MessageResponse> deleteMedicalHistory(@PathVariable Long healthStatusId) {
+		medicalHistoryService.deleteMedicalHistory(healthStatusId);
+		return ResponseEntity.ok(new MessageResponse("The health status has been deleted."));
+	}
+}

--- a/src/main/java/com/onebridge/ouch/converter/MedicalHistoryConverter.java
+++ b/src/main/java/com/onebridge/ouch/converter/MedicalHistoryConverter.java
@@ -1,0 +1,47 @@
+package com.onebridge.ouch.converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.onebridge.ouch.domain.MedicalHistory;
+import com.onebridge.ouch.dto.medicalHistory.response.DateAndDisease;
+import com.onebridge.ouch.dto.medicalHistory.response.GetMedicalHistoryResponse;
+import com.onebridge.ouch.dto.medicalHistory.response.MedicalHistoryCreateResponse;
+import com.onebridge.ouch.dto.medicalHistory.response.MedicalHistoryUpdateResponse;
+
+@Component
+public class MedicalHistoryConverter {
+	public MedicalHistoryCreateResponse medicalHistory2MedicalHistoryResponse(MedicalHistory medicalHistory,
+		Long userId) {
+		return new MedicalHistoryCreateResponse(medicalHistory.getId(),
+			medicalHistory.getDisease(),
+			medicalHistory.getAllergy(),
+			medicalHistory.getBloodPressure(), medicalHistory.getBloodSugar(), medicalHistory.getMedicineHistory());
+	}
+
+	public List<DateAndDisease> medicalHistory2GetUsersAllMedicalHistoryResponse(
+		List<MedicalHistory> medicalHistory) {
+
+		List<DateAndDisease> list = new ArrayList<>();
+
+		for (MedicalHistory history : medicalHistory) {
+			list.add(new DateAndDisease(history.getId(), history.getUpdatedAt().toString(), history.getDisease()));
+		}
+
+		return list;
+	}
+
+	public GetMedicalHistoryResponse medicalHistory2GetMedicalHistoryResponse(MedicalHistory medicalHistory) {
+		return new GetMedicalHistoryResponse(medicalHistory.getId(), medicalHistory.getDisease(),
+			medicalHistory.getAllergy(), medicalHistory.getBloodPressure(), medicalHistory.getBloodSugar(),
+			medicalHistory.getMedicineHistory());
+	}
+
+	public MedicalHistoryUpdateResponse medicalHistory2MedicalHistoryUpdateResponse(MedicalHistory medicalHistory) {
+		return new MedicalHistoryUpdateResponse(medicalHistory.getId(), medicalHistory.getDisease(),
+			medicalHistory.getAllergy(), medicalHistory.getBloodPressure(), medicalHistory.getBloodSugar(),
+			medicalHistory.getMedicineHistory());
+	}
+}

--- a/src/main/java/com/onebridge/ouch/domain/MedicalHistory.java
+++ b/src/main/java/com/onebridge/ouch/domain/MedicalHistory.java
@@ -2,24 +2,51 @@ package com.onebridge.ouch.domain;
 
 import com.onebridge.ouch.domain.common.BaseEntity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class MedicalHistory extends BaseEntity {
 
 	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-	@MapsId // User의 id를 MedicalHistory의 기본 키로 매핑
-	@JoinColumn(name = "user_id") //외래 키 이름을 user_id로 설정
+	@ManyToOne(fetch = FetchType.LAZY) //cascade = CascadeType.ALL -> medicalHistory 삭제 시 user 도 삭제됨
+	// @JoinColumn(name = "user_id") //외래 키 이름을 user_id로 설정
+	@JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "fk_medical_history_user",
+		value = ConstraintMode.CONSTRAINT, foreignKeyDefinition = "ON DELETE CASCADE"))
 	private User user;
 
 	@Column(nullable = true, columnDefinition = "TEXT")
-	private String contents;
+	private String disease;
+
+	@Column(nullable = true, columnDefinition = "TEXT")
+	private String allergy;
+
+	@Column(nullable = true, columnDefinition = "TEXT")
+	private Long bloodPressure;
+
+	@Column(nullable = true, columnDefinition = "TEXT")
+	private Long bloodSugar;
+
+	@Column(nullable = true, columnDefinition = "TEXT")
+	private String medicineHistory;
 }

--- a/src/main/java/com/onebridge/ouch/dto/medicalHistory/request/MedicalHistoryCreateRequest.java
+++ b/src/main/java/com/onebridge/ouch/dto/medicalHistory/request/MedicalHistoryCreateRequest.java
@@ -1,0 +1,26 @@
+package com.onebridge.ouch.dto.medicalHistory.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MedicalHistoryCreateRequest {
+
+	@NotBlank(message = "Disease is required.")
+	private String disease;
+
+	@NotBlank(message = "Allergy is required.")
+	private String allergy;
+
+	@NotNull(message = "Blood pressure is required.")
+	private Long bloodPressure;
+
+	@NotNull(message = "Blood sugar level is required.")
+	private Long bloodSugar;
+
+	@NotBlank(message = "Medical History is required.")
+	private String medicineHistory;
+}

--- a/src/main/java/com/onebridge/ouch/dto/medicalHistory/request/MedicalHistoryUpdateRequest.java
+++ b/src/main/java/com/onebridge/ouch/dto/medicalHistory/request/MedicalHistoryUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.onebridge.ouch.dto.medicalHistory.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MedicalHistoryUpdateRequest {
+
+	@NotBlank(message = "Disease is required.")
+	private String disease;
+
+	@NotBlank(message = "Allergy is required.")
+	private String allergy;
+
+	@NotNull(message = "Blood pressure is required.")
+	private Long bloodPressure;
+
+	@NotNull(message = "Blood sugar level is required.")
+	private Long bloodSugar;
+
+	@NotBlank(message = "Medical History is required.")
+	private String medicineHistory;
+}

--- a/src/main/java/com/onebridge/ouch/dto/medicalHistory/response/DateAndDisease.java
+++ b/src/main/java/com/onebridge/ouch/dto/medicalHistory/response/DateAndDisease.java
@@ -1,0 +1,13 @@
+package com.onebridge.ouch.dto.medicalHistory.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DateAndDisease {
+
+	private Long id;
+	private String date;
+	private String disease;
+}

--- a/src/main/java/com/onebridge/ouch/dto/medicalHistory/response/GetMedicalHistoryResponse.java
+++ b/src/main/java/com/onebridge/ouch/dto/medicalHistory/response/GetMedicalHistoryResponse.java
@@ -1,0 +1,18 @@
+package com.onebridge.ouch.dto.medicalHistory.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class GetMedicalHistoryResponse {
+
+	private Long id;
+	private String disease;
+	private String allergy;
+	private Long bloodPressure;
+	private Long bloodSugar;
+	private String medicineHistory;
+}

--- a/src/main/java/com/onebridge/ouch/dto/medicalHistory/response/MedicalHistoryCreateResponse.java
+++ b/src/main/java/com/onebridge/ouch/dto/medicalHistory/response/MedicalHistoryCreateResponse.java
@@ -1,0 +1,17 @@
+package com.onebridge.ouch.dto.medicalHistory.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class MedicalHistoryCreateResponse {
+	private Long id;
+	private String disease;
+	private String allergy;
+	private Long bloodPressure;
+	private Long bloodSugar;
+	private String medicineHistory;
+}

--- a/src/main/java/com/onebridge/ouch/dto/medicalHistory/response/MedicalHistoryUpdateResponse.java
+++ b/src/main/java/com/onebridge/ouch/dto/medicalHistory/response/MedicalHistoryUpdateResponse.java
@@ -1,0 +1,17 @@
+package com.onebridge.ouch.dto.medicalHistory.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class MedicalHistoryUpdateResponse {
+	private Long id;
+	private String disease;
+	private String allergy;
+	private Long bloodPressure;
+	private Long bloodSugar;
+	private String medicineHistory;
+}

--- a/src/main/java/com/onebridge/ouch/repository/medicalHistory/MedicalHistoryRepository.java
+++ b/src/main/java/com/onebridge/ouch/repository/medicalHistory/MedicalHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.onebridge.ouch.repository.medicalHistory;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.onebridge.ouch.domain.MedicalHistory;
+
+@Repository
+public interface MedicalHistoryRepository extends JpaRepository<MedicalHistory, Long> {
+	List<MedicalHistory> findAllByUserId(Long userId);
+}

--- a/src/main/java/com/onebridge/ouch/service/medicalHistory/MedicalHistoryService.java
+++ b/src/main/java/com/onebridge/ouch/service/medicalHistory/MedicalHistoryService.java
@@ -1,0 +1,97 @@
+package com.onebridge.ouch.service.medicalHistory;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.onebridge.ouch.apiPayload.code.error.MedicalHistoryErrorCode;
+import com.onebridge.ouch.apiPayload.exception.OuchException;
+import com.onebridge.ouch.converter.MedicalHistoryConverter;
+import com.onebridge.ouch.domain.MedicalHistory;
+import com.onebridge.ouch.domain.User;
+import com.onebridge.ouch.dto.medicalHistory.request.MedicalHistoryCreateRequest;
+import com.onebridge.ouch.dto.medicalHistory.request.MedicalHistoryUpdateRequest;
+import com.onebridge.ouch.dto.medicalHistory.response.DateAndDisease;
+import com.onebridge.ouch.dto.medicalHistory.response.GetMedicalHistoryResponse;
+import com.onebridge.ouch.dto.medicalHistory.response.MedicalHistoryCreateResponse;
+import com.onebridge.ouch.dto.medicalHistory.response.MedicalHistoryUpdateResponse;
+import com.onebridge.ouch.repository.medicalHistory.MedicalHistoryRepository;
+import com.onebridge.ouch.repository.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MedicalHistoryService {
+
+	private final UserRepository userRepository;
+	private final MedicalHistoryConverter medicalHistoryConverter;
+	private final MedicalHistoryRepository medicalHistoryRepository;
+
+	//건강상태 생성
+	@Transactional
+	public MedicalHistoryCreateResponse createMedicalHistory(MedicalHistoryCreateRequest request, Long userId) {
+		MedicalHistory medicalHistory = MedicalHistory.builder()
+			.user(userRepository.findById(userId)
+				.orElseThrow(() -> new OuchException(MedicalHistoryErrorCode.USER_NOT_FOUND)))
+			.disease(request.getDisease())
+			.allergy(request.getAllergy())
+			.bloodPressure(request.getBloodPressure())
+			.bloodSugar(request.getBloodSugar())
+			.medicineHistory(request.getMedicineHistory())
+			.build();
+
+		medicalHistoryRepository.save(medicalHistory);
+
+		return medicalHistoryConverter.medicalHistory2MedicalHistoryResponse(medicalHistory, userId);
+	}
+
+	//특정 건강상태 조회
+	@Transactional
+	public GetMedicalHistoryResponse getMedicalHistory(Long medicalHistoryId) {
+		MedicalHistory medicalHistory = medicalHistoryRepository.findById(medicalHistoryId)
+			.orElseThrow(() -> new OuchException(MedicalHistoryErrorCode.MEDICAL_HISTORY_NOT_FOUND));
+		return medicalHistoryConverter.medicalHistory2GetMedicalHistoryResponse(medicalHistory);
+	}
+
+	//특정 사용자의 모든 건강상태 조회
+	@Transactional
+	public List<DateAndDisease> getUsersAllMedicalHistory(Long userId) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new OuchException(MedicalHistoryErrorCode.USER_NOT_FOUND));
+
+		List<MedicalHistory> medicalHistory = medicalHistoryRepository.findAllByUserId(userId);
+		return medicalHistoryConverter.medicalHistory2GetUsersAllMedicalHistoryResponse(medicalHistory);
+	}
+
+	//특정 건강상태 수정
+	@Transactional
+	public MedicalHistoryUpdateResponse updateMedicalHistory(MedicalHistoryUpdateRequest request,
+		Long medicalHistoryId) {
+		MedicalHistory medicalHistory = medicalHistoryRepository.findById(medicalHistoryId)
+			.orElseThrow(() -> new OuchException(MedicalHistoryErrorCode.MEDICAL_HISTORY_NOT_FOUND));
+
+		MedicalHistory updatedMedicalHistory = medicalHistory.toBuilder()
+			.disease(request.getDisease())
+			.allergy(request.getAllergy())
+			.bloodPressure(request.getBloodPressure())
+			.bloodSugar(request.getBloodSugar())
+			.medicineHistory(request.getMedicineHistory())
+			.build();
+
+		medicalHistoryRepository.save(updatedMedicalHistory);
+
+		return medicalHistoryConverter.medicalHistory2MedicalHistoryUpdateResponse(updatedMedicalHistory);
+	}
+
+	//특정 건강상태 삭제
+	@Transactional
+	public void deleteMedicalHistory(Long medicalHistoryId) {
+		MedicalHistory medicalHistory = medicalHistoryRepository.findById(medicalHistoryId)
+			.orElseThrow(() -> new OuchException(MedicalHistoryErrorCode.MEDICAL_HISTORY_NOT_FOUND));
+
+		medicalHistoryRepository.delete(medicalHistory);
+	}
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: 건강상태 CRUD api 구현(#34)

## 📌 관련 이슈

- closing: #34 

## ✨ PR 세부 내용

[건강상태]

- 건강상태 생성 
- 특정 건강상태 조회
- 특정 사용자의 모든 건강상태 조회
- 특정 건강상태 수정
- 특정 건강상태 삭제


## 💬 **리뷰 요청 사항**
